### PR TITLE
Generalize MacOS version check for force-upcast-attention

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -884,7 +884,8 @@ def pytorch_attention_flash_attention():
 def force_upcast_attention_dtype():
     upcast = args.force_upcast_attention
     try:
-        if platform.mac_ver()[0] in ['14.5']: #black image bug on OSX Sonoma 14.5
+        macos_version = tuple(int(n) for n in platform.mac_ver()[0].split("."))
+        if (14, 5) <= macos_version < (14, 7):  # black image bug on recent versions of MacOS
             upcast = True
     except:
         pass


### PR DESCRIPTION
This code automatically forces upcasting attention for MacOS versions 14.5 and 14.6. My computer returns the string "14.6.1" for `platform.mac_ver()[0]`, so this generalizes the comparison to catch more versions.

I am running MacOS Sonoma 14.6.1 (latest version) and was seeing black image generation on previously functional workflows after recent software updates. This PR solved the issue for me.

See comfyanonymous/ComfyUI#3521

This preempts cli arg `--force-upcast-attention`. Note that I have not tested other versions of MacOS, and this may need to be modified to affect future versions beyond 14.6 as well.